### PR TITLE
fix(exports): remove double `.png` from exported file name

### DIFF
--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -239,7 +239,7 @@
       canvas = pskl.utils.ImageResizer.resize(canvas, canvas.width * zoom, canvas.height * zoom, false);
     }
 
-    var fileName = name + '-' + (frameIndex + 1) + '.png';
+    var fileName = name + '-' + (frameIndex + 1);
     this.downloadCanvas_(canvas, fileName);
   };
 })();


### PR DESCRIPTION
Closes: piskelapp#985